### PR TITLE
use digicert to sign windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,8 @@ on:
     branches:
       - master
       - preview/*
-    # uncomment after first official release.
-    # tags:
-    #   - 'v*.*.*'
+    tags:
+      - 'v*.*.*'
 
 jobs:
   publish-tauri:
@@ -159,32 +158,60 @@ jobs:
             SHA256SUMS
             SHA256SUMS.asc
 
-      # # === Windows EV Signing ===
-      # - name: Write Windows EV Certificate to file
-      #   if: matrix.platform == 'windows-latest'
-      #   run: |
-      #     echo $env:WINDOWS_EV_CERTIFICATE > windows_cert.pfx
-      #   env:
-      #     WINDOWS_EV_CERTIFICATE: ${{ secrets.WINDOWS_EV_CERTIFICATE }}
-
-      # - name: Sign Windows Binary with EV Certificate
-      #   if: matrix.platform == 'windows-latest'
-      #   run: |
-      #     signtool sign /f windows_cert.pfx /p %WINDOWS_EV_CERTIFICATE_PASSWORD% /tr http://timestamp.digicert.com /td sha256 /fd sha256 path\to\metanet-desktop-setup.exe
-      #   env:
-      #     WINDOWS_EV_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_EV_CERTIFICATE_PASSWORD }}
-
-      # - name: Verify Windows Signature
-      #   if: matrix.platform == 'windows-latest'
-      #   run: |
-      #     signtool verify /pa /v path\to\metanet-desktop-setup.exe
-      
-      - name: List Windows build artifacts for debugging
+      - name: Set up certificate 
         if: matrix.platform == 'windows-latest'
-        shell: powershell
+        run: | 
+          echo "${{ secrets.DIGICERT_CLIENT_AUTH_CERT }}" | base64 --decode > /d/Certificate_pkcs12.p12 
+        shell: bash
+
+      - name: Set DigiCert environment variables
+        if: matrix.platform == 'windows-latest'
         run: |
-          Write-Host "Checking build directory structure:"
-          Get-ChildItem -Path src-tauri\target\release -Recurse | Where-Object { $_.Name -like "*.exe" } | ForEach-Object { $_.FullName }
+          echo "SM_HOST=${{ secrets.DIGICERT_HOST }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.DIGICERT_KEY_LOCKER_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_FINGERPRINT=${{ secrets.DIGICERT_CODE_SIGNING_SHA1_HASH }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.DIGICERT_CLIENT_AUTH_PASS }}" >> "$GITHUB_ENV" 
+        shell: bash
+
+      - name: Code signing with Software Trust Manager
+        if: matrix.platform == 'windows-latest'
+        uses: digicert/ssm-code-signing@v1.1.0
+        env:
+          FORCE_DOWNLOAD_TOOLS: 'true' 
+
+      - name: DigiCert tools healthcheck
+        if: matrix.platform == 'windows-latest'
+        shell: cmd
+        run: |
+          smctl version
+          smctl healthcheck
+
+      - name: Sync KeyLocker certificate to Windows store (KSP)
+        if: matrix.platform == 'windows-latest'
+        shell: cmd
+        run: |
+          "%LOCALAPPDATA%\Temp\smtools-windows-x64\smksp_cert_sync.exe"
+          certutil.exe -csp "DigiCert Software Trust Manager KSP" -key -user
+
+      - name: Sign Windows executables with DigiCert (KSP)
+        if: matrix.platform == 'windows-latest'
+        shell: cmd
+        run: |
+          for /r "src-tauri\target\release\bundle" %%f in (*.exe *.msi) do (
+            smctl sign --fingerprint %SM_FINGERPRINT% --input "%%f"
+          )
+
+      - name: Verify Windows Signatures
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $signtool) { throw "signtool.exe not found. Ensure Windows 10 SDK is installed on the runner." }
+          $files = Get-ChildItem -Recurse -Path src-tauri\target\release\bundle\ -Include *.exe,*.msi | Select-Object -ExpandProperty FullName
+          foreach ($file in $files) {
+            & $signtool verify /pa "$file"
+          }
 
       - name: Upload Windows Artifact - MSI
         if: matrix.platform == 'windows-latest'
@@ -203,3 +230,10 @@ jobs:
             src-tauri/target/release/bundle/nsis/*.exe
             src-tauri/target/release/bundle/nsis-web/*.exe
           if-no-files-found: warn
+      
+      - name: List Windows build artifacts for debugging
+        if: matrix.platform == 'windows-latest'
+        shell: powershell
+        run: |
+          Write-Host "Checking build directory structure:"
+          Get-ChildItem -Path src-tauri\target\release -Recurse | Where-Object { $_.Name -like "*.exe" } | ForEach-Object { $_.FullName }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,9 +11,13 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "metanet_desktop"
+name = "metanet_desktop_lib"
 path = "src/lib.rs"
 crate-type = ["staticlib", "cdylib", "rlib"]
+
+[[bin]]
+name = "metanet-desktop"
+path = "src/main.rs"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
DigiCert Software Trust Manager

remove the stuff we know works
updated workflow
try these windows only
credentials
fix workflow
reattempt
wrong api key
convert to a binary cert file
try this
try again
GPT 5 has a go
unknown flag debug
IT worked, so adding back linux and macos versions

Month of Digitcert hell finally resolved.